### PR TITLE
feat(oauth): seed SaaS.Studio dashboard as first-party trusted client

### DIFF
--- a/src/sdk/oauth/clients.ts
+++ b/src/sdk/oauth/clients.ts
@@ -96,6 +96,20 @@ export const DEFAULT_OAUTH_CLIENTS: readonly DefaultClient[] = [
     trusted: true,
     tokenEndpointAuthMethod: 'none',
   },
+  {
+    id: 'saas_studio_dash',
+    name: 'SaaS.Studio',
+    redirectUris: [
+      'https://app.saas.studio/auth/callback',
+      'https://saas.studio/auth/callback',
+      'http://localhost:3000/auth/callback',
+    ],
+    grantTypes: ['authorization_code', 'refresh_token'],
+    responseTypes: ['code'],
+    scopes: ['openid', 'profile', 'email', 'offline_access'],
+    trusted: true,
+    tokenEndpointAuthMethod: 'none',
+  },
 ] as const
 
 /**

--- a/test/oauth-default-clients.test.ts
+++ b/test/oauth-default-clients.test.ts
@@ -58,6 +58,19 @@ describe('seedDefaultClients', () => {
     expect(store.get('client:id_org_ai_headlessly')).toBeDefined()
   })
 
+  it('seeds SaaS.Studio dashboard web client (trusted, authorization_code + refresh)', async () => {
+    await seedDefaultClients(storage)
+    const client = store.get('client:saas_studio_dash') as Record<string, unknown> | undefined
+    expect(client).toBeDefined()
+    expect(client!.name).toBe('SaaS.Studio')
+    expect(client!.trusted).toBe(true)
+    expect(client!.grantTypes).toContain('authorization_code')
+    expect(client!.grantTypes).toContain('refresh_token')
+    expect(client!.redirectUris).toContain('https://app.saas.studio/auth/callback')
+    expect(client!.redirectUris).toContain('http://localhost:3000/auth/callback')
+    expect(client!.scopes).toContain('offline_access')
+  })
+
   it('does not overwrite existing clients (idempotent)', async () => {
     store.set('client:id_org_ai_cli', { id: 'id_org_ai_cli', name: 'Custom Name' })
     await seedDefaultClients(storage)


### PR DESCRIPTION
Adds the SaaS.Studio dashboard (`app.saas.studio`) to `DEFAULT_OAUTH_CLIENTS` as a first-party trusted client, alongside `id.org.ai Dashboard`, `Headless.ly`, and `auto.dev Web`.

## Why first-party / trusted

SaaS.Studio is in the same `.studio` family — it's our own dashboard, not a third party. The existing pattern in `src/sdk/oauth/clients.ts` already covers exactly this case for headless.ly and auto.dev. `trusted: true` skips the consent screen on first sign-in (we already trust ourselves); `tokenEndpointAuthMethod: 'none'` + PKCE means no client secret to leak through the Next.js route handler.

## Client config

- **id**: `saas_studio_dash`
- **redirect_uris**:
  - `https://app.saas.studio/auth/callback` (production)
  - `https://saas.studio/auth/callback` (production fallback while subdomain rollout settles)
  - `http://localhost:3000/auth/callback` (dev)
- **scopes**: `openid profile email offline_access`
- **grants**: `authorization_code` + `refresh_token`

## MFA

Enforced upstream by the WorkOS AuthKit integration (the human-auth path id.org.ai wraps). No client-side opt-in needed.

## Test

Added a dedicated test case for the new client in `test/oauth-default-clients.test.ts`; the existing 'every client in DEFAULT_OAUTH_CLIENTS' contract test also covers it. All 7 tests in the file pass.

## Deployment

This file is consumed at runtime by `seedDefaultClients()`, which is called lazily on first `/oauth/authorize` (web clients) per request. After deploy, the new client is seeded the first time anything hits authorize.

Refs dot-do/saas.studio#29

🤖 Generated with [Claude Code](https://claude.com/claude-code)