### PR TITLE
id.org.ai: trusted-account OAuth mode for in-CF-account consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,30 @@ The MCP spec moved to CIMD (Client ID Metadata Documents) as the default. For an
 
 id.org.ai wraps WorkOS AuthKit for all human authentication. The custom AuthKit domain is `id.org.ai`. WorkOS handles SSO, social login, MFA, enterprise directory sync. id.org.ai adds the agent layer on top.
 
+### Trusted-Account OAuth (ADR-0007)
+
+Consumer domains that live in the **same Cloudflare account** as id.org.ai can integrate without per-app Dynamic Client Registration. Account membership *is* the trust boundary.
+
+A single canonical client_id — `cid_trusted_account_v1` — is recognized at `/oauth/authorize` and `/oauth/token` for any `redirect_uri` whose host is in the `TRUSTED_ACCOUNT_DOMAINS` allowlist (worker env var, comma-separated bare hostnames). PKCE remains mandatory; scope and state validation are unchanged. There is no client_secret — it's a public client.
+
+Implementation choice: the trusted-account client is fully synthesized from env config at request time. There is no `client:cid_trusted_account_v1` row in the DCR store; the lookup is bypassed when the incoming client_id matches the canonical id. This avoids a one-time bootstrap step and means the allowlist is the single source of truth.
+
+**Onboarding a new in-account consumer:**
+
+1. Add the consumer's apex (or relevant) hostname to `TRUSTED_ACCOUNT_DOMAINS` in `worker/wrangler.jsonc`.
+2. Redeploy id.org.ai.
+3. On the consumer side, configure your OAuth client (e.g. better-auth) with:
+   - `issuer = https://id.org.ai`
+   - `client_id = cid_trusted_account_v1`
+   - `redirect_uri` on a host matching the allowlist
+   - PKCE (S256), no client_secret
+
+That's it — no DCR call, no `client_id` paste, no env-var coordination. Removing a consumer is the inverse: remove its host from the allowlist and redeploy. Existing DCR'd clients (`cid_*` records in storage) continue to work unchanged for third-party consumers.
+
+Trade-off: per-app revocation is coarser. Revoking the trusted-account client invalidates every in-account consumer at once. The intended granularity is per-domain via the allowlist.
+
+See [`docs/adr/0007-trusted-account-oauth-via-better-auth.md`](https://github.com/dot-do/startup.games/blob/main/docs/adr/0007-trusted-account-oauth-via-better-auth.md) for the full rationale.
+
 ## Implementation Phases
 
 ### Phase 1: Anonymous → Sandboxed (Level 0 → 1)

--- a/src/sdk/oauth/provider.ts
+++ b/src/sdk/oauth/provider.ts
@@ -62,6 +62,27 @@ export interface OAuthConfig {
   jwksUri?: string
 }
 
+/**
+ * Trusted-account OAuth configuration (ADR-0007).
+ *
+ * When a request arrives with `client_id === clientId` and the request's
+ * `redirect_uri` host is in `allowedDomains`, the OAuth flow bypasses the
+ * usual DCR `client:{cid_*}` storage lookup and treats the request as
+ * coming from a public client whose redirect_uri list is implicit-via-
+ * allowlist. PKCE remains mandatory; scope/state validation are unchanged.
+ *
+ * This implements option (b) from ADR-0007: bypass DCR lookup entirely for
+ * the canonical client rather than provisioning a real DCR record. Chosen
+ * to keep the diff small and avoid a one-time bootstrap step — the trusted-
+ * account "client" is fully synthesized from env config at request time.
+ */
+export interface TrustedAccountConfig {
+  /** Canonical shared client_id for in-Cloudflare-account consumers. */
+  clientId: string
+  /** Bare hostnames (no scheme/path) accepted as redirect_uri hosts. */
+  allowedDomains: Set<string>
+}
+
 export interface OAuthProviderClient {
   id: string                   // cid_xxx
   name: string
@@ -279,6 +300,7 @@ export class OAuthProvider {
   private config: OAuthConfig
   private getIdentity: (id: string) => Promise<IdentityInfo | null>
   private signingKeyManager?: SigningKeyManager
+  private trustedAccount?: TrustedAccountConfig
 
   get issuer(): string {
     return this.config.issuer
@@ -303,11 +325,66 @@ export class OAuthProvider {
     config: OAuthConfig
     getIdentity: (id: string) => Promise<IdentityInfo | null>
     signingKeyManager?: SigningKeyManager
+    /** ADR-0007: trusted-account OAuth mode for in-CF-account consumers. */
+    trustedAccount?: TrustedAccountConfig
   }) {
     this.storage = options.storage
     this.config = options.config
     this.getIdentity = options.getIdentity
     this.signingKeyManager = options.signingKeyManager
+    this.trustedAccount = options.trustedAccount
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // PRIVATE: Trusted-Account Helpers (ADR-0007)
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  /** True iff `clientId` is the canonical trusted-account client id. */
+  private isTrustedAccountClient(clientId: string): boolean {
+    return !!this.trustedAccount && clientId === this.trustedAccount.clientId
+  }
+
+  /**
+   * Returns true if `redirectUri` parses cleanly, uses https (or localhost
+   * for dev), and its host is in the trusted-account allowlist.
+   */
+  private isTrustedAccountRedirect(redirectUri: string): boolean {
+    if (!this.trustedAccount) return false
+    let parsed: URL
+    try {
+      parsed = new URL(redirectUri)
+    } catch {
+      return false
+    }
+    if (parsed.protocol !== 'https:' && parsed.hostname !== 'localhost' && parsed.hostname !== '127.0.0.1') {
+      return false
+    }
+    if (parsed.hash) return false
+    return this.trustedAccount.allowedDomains.has(parsed.hostname)
+  }
+
+  /**
+   * Synthesize a virtual `OAuthProviderClient` for the canonical trusted-
+   * account client. Used in place of a DCR storage lookup. `redirectUris`
+   * is intentionally empty — host validation is performed separately
+   * against the allowlist via {@link isTrustedAccountRedirect}.
+   */
+  private buildTrustedAccountClient(): OAuthProviderClient {
+    return {
+      id: this.trustedAccount!.clientId,
+      name: 'Trusted Account Consumer',
+      // No secret — this is a public client; PKCE is enforced as usual.
+      redirectUris: [], // implicit-via-allowlist; do not validate via this array
+      grantTypes: ['authorization_code', 'refresh_token'],
+      responseTypes: ['code'],
+      // Standard OIDC scopes; per-app scope narrowing is not needed under
+      // the trusted-account model — account membership is the trust boundary.
+      scopes: ['openid', 'profile', 'email', 'offline_access'],
+      // First-party: skip consent screen. Account membership = consent.
+      trusted: true,
+      tokenEndpointAuthMethod: 'none',
+      createdAt: 0,
+    }
   }
 
   // ═══════════════════════════════════════════════════════════════════════════
@@ -440,14 +517,26 @@ export class OAuthProvider {
     const resource = params.get('resource') || undefined
 
     // ── Validate client ─────────────────────────────────────────────────
-    const client = await this.getClient(clientId)
-    if (!client) {
-      return oauthError('invalid_client', 'Unknown client_id')
-    }
-
-    // ── Validate redirect URI ───────────────────────────────────────────
-    if (!client.redirectUris.includes(redirectUri)) {
-      return oauthError('invalid_request', 'Invalid redirect_uri')
+    // ADR-0007: trusted-account clients bypass the DCR lookup entirely.
+    // Their redirect_uri allowlist is host-based and supplied by env config.
+    let client: OAuthProviderClient | null
+    if (this.isTrustedAccountClient(clientId)) {
+      if (!this.isTrustedAccountRedirect(redirectUri)) {
+        return oauthError(
+          'invalid_request',
+          'redirect_uri host is not in the trusted-account allowlist',
+        )
+      }
+      client = this.buildTrustedAccountClient()
+    } else {
+      client = await this.getClient(clientId)
+      if (!client) {
+        return oauthError('invalid_client', 'Unknown client_id')
+      }
+      // Validate redirect URI against the DCR-registered list
+      if (!client.redirectUris.includes(redirectUri)) {
+        return oauthError('invalid_request', 'Invalid redirect_uri')
+      }
     }
 
     // ── Validate response_type ──────────────────────────────────────────
@@ -931,6 +1020,22 @@ export class OAuthProvider {
       return oauthError('invalid_grant', 'redirect_uri mismatch')
     }
 
+    // ── ADR-0007: re-verify host against trusted-account allowlist ──────
+    // Defense in depth: even though the redirect_uri matches the one stored
+    // on the code (which was validated at /authorize time), re-check that
+    // its host is still in the allowlist. This catches an allowlist that
+    // shrank between authorize and token exchange.
+    if (this.isTrustedAccountClient(clientId)) {
+      if (!this.isTrustedAccountRedirect(redirectUri)) {
+        return oauthError(
+          'invalid_grant',
+          'redirect_uri host is not in the trusted-account allowlist',
+        )
+      }
+      // Trusted-account is a public client — no client_secret required.
+      // Fall through to PKCE verification below.
+    }
+
     // ── Verify PKCE (mandatory per OAuth 2.1) ───────────────────────────
     if (codeData.codeChallenge) {
       if (!codeVerifier) {
@@ -941,8 +1046,9 @@ export class OAuthProvider {
       if (computedChallenge !== codeData.codeChallenge) {
         return oauthError('invalid_grant', 'Invalid code_verifier')
       }
-    } else {
-      // No PKCE — confidential client must present valid secret
+    } else if (!this.isTrustedAccountClient(clientId)) {
+      // No PKCE — confidential client must present valid secret.
+      // (Trusted-account clients always have PKCE per /authorize enforcement.)
       const client = await this.getClient(clientId)
       if (client?.secret && client.secret !== clientSecret) {
         return oauthError('invalid_client', 'Invalid client credentials', 401)

--- a/src/sdk/oauth/provider.ts
+++ b/src/sdk/oauth/provider.ts
@@ -137,6 +137,16 @@ interface RefreshToken {
   createdAt: number
   resource?: string            // RFC 8707 resource indicator
   effectiveIssuer?: string     // multi-tenant: issuer override from X-Issuer header
+  /**
+   * ADR-0007: the consumer's redirect_uri host at issuance time, captured for
+   * trusted-account flows so `handleRefreshTokenGrant` can re-validate the
+   * host against the current allowlist. Removing a domain from
+   * TRUSTED_ACCOUNT_DOMAINS must invalidate live refresh tokens for that
+   * domain, otherwise per-app revocation (ADR-0007 §"per-app revocation")
+   * doesn't actually hold for the refresh grant. Unset for non-trusted-
+   * account flows.
+   */
+  consumerHost?: string
 }
 
 // Internal storage type — see OAuthDeviceCode in ./types.ts for canonical API type
@@ -1089,10 +1099,11 @@ export class OAuthProvider {
     await this.storage.delete(`code:${code}`)
 
     // ── Issue tokens ────────────────────────────────────────────────────
-    // ADR-0007 (BLOCKER 2): forward the consumer host to issueTokenPair so
-    // its `oauth.token.issued` audit event can record it. Computed from the
-    // redirect_uri the code was bound to (already verified above).
-    const redirectUriHost = this.isTrustedAccountClient(clientId)
+    // ADR-0007: stamp the consumer host on the refresh token so the
+    // refresh-grant path can re-check it against the current allowlist
+    // (per-app revocation by domain removal). Also feeds the
+    // `oauth.token.issued` audit event's `redirectUriHost` field.
+    const consumerHost = this.isTrustedAccountClient(clientId)
       ? this.extractRedirectUriHost(codeData.redirectUri)
       : undefined
 
@@ -1103,7 +1114,7 @@ export class OAuthProvider {
       nonce: codeData.nonce,
       resource: codeData.resource,
       effectiveIssuer: codeData.effectiveIssuer,
-      redirectUriHost,
+      consumerHost,
     })
   }
 
@@ -1129,9 +1140,29 @@ export class OAuthProvider {
     }
 
     // ── Verify client secret for confidential clients ───────────────────
-    const client = await this.getClient(clientId)
-    if (client?.secret && client.secret !== clientSecret) {
-      return oauthError('invalid_client', 'Invalid client credentials', 401)
+    // Trusted-account is a public client (no secret); skip the lookup so we
+    // don't materialise a DCR row for it.
+    if (!this.isTrustedAccountClient(clientId)) {
+      const client = await this.getClient(clientId)
+      if (client?.secret && client.secret !== clientSecret) {
+        return oauthError('invalid_client', 'Invalid client credentials', 401)
+      }
+    }
+
+    // ── ADR-0007 (QUESTION resolved): re-validate consumer host against ──
+    //     the current trusted-account allowlist. The authorize-code grant
+    //     does the same check at code → token exchange; refresh must fail
+    //     closed when a domain is removed from TRUSTED_ACCOUNT_DOMAINS,
+    //     otherwise "per-app revocation" (ADR-0007 §"Negative / mitigations")
+    //     doesn't actually hold for the refresh grant.
+    if (this.isTrustedAccountClient(clientId)) {
+      const host = tokenData.consumerHost
+      if (!host || !this.trustedAccount!.allowedDomains.has(host)) {
+        return oauthError(
+          'invalid_grant',
+          'redirect_uri host is not in the trusted-account allowlist',
+        )
+      }
     }
 
     // ── Check if revoked (replay detection) ─────────────────────────────
@@ -1161,6 +1192,9 @@ export class OAuthProvider {
       family: tokenData.family,
       resource: tokenData.resource,
       effectiveIssuer: tokenData.effectiveIssuer,
+      // Propagate the consumer host through rotation so subsequent refreshes
+      // can keep enforcing the allowlist (ADR-0007).
+      consumerHost: tokenData.consumerHost,
     })
   }
 
@@ -1343,7 +1377,9 @@ export class OAuthProvider {
 
   /**
    * Extract the bare hostname from a redirect_uri, or undefined if the URI
-   * doesn't parse. Used for audit-event `redirectUriHost` (ADR-0007 BLOCKER 2).
+   * doesn't parse. Used for audit-event `redirectUriHost` (ADR-0007 BLOCKER 2)
+   * and for the consumerHost stamped on trusted-account refresh tokens (the
+   * QUESTION resolution in PR #8 review).
    */
   private extractRedirectUriHost(redirectUri: string): string | undefined {
     try {
@@ -1383,13 +1419,15 @@ export class OAuthProvider {
     resource?: string
     effectiveIssuer?: string
     /**
-     * ADR-0007 (BLOCKER 2): consumer's redirect_uri host, captured for the
-     * `oauth.token.issued` audit event metadata. Trusted-account flows only;
-     * ignored for everything else.
+     * ADR-0007: consumer's redirect_uri host. Stored on the refresh-token
+     * record so `handleRefreshTokenGrant` can re-validate against the
+     * current allowlist (QUESTION resolution from PR #8 review). Also used
+     * as the `redirectUriHost` audit metadata field. Trusted-account flows
+     * only; ignored for everything else.
      */
-    redirectUriHost?: string
+    consumerHost?: string
   }): Promise<Response> {
-    const { clientId, identityId, scopes, family, nonce, resource, effectiveIssuer, redirectUriHost } = options
+    const { clientId, identityId, scopes, family, nonce, resource, effectiveIssuer, consumerHost } = options
     const now = Date.now()
     const accessTokenId = generateId('at_')
     const refreshTokenId = generateId('rt_')
@@ -1415,6 +1453,7 @@ export class OAuthProvider {
       createdAt: now,
       ...(resource !== undefined && { resource }),
       ...(effectiveIssuer !== undefined && { effectiveIssuer }),
+      ...(consumerHost !== undefined && { consumerHost }),
     }
 
     await this.storage.put(`access:${accessTokenId}`, accessToken, {
@@ -1435,7 +1474,7 @@ export class OAuthProvider {
         metadata: {
           clientId,
           identityId,
-          redirectUriHost,
+          redirectUriHost: consumerHost,
           refreshTokenId,
           scopes,
         },

--- a/src/sdk/oauth/provider.ts
+++ b/src/sdk/oauth/provider.ts
@@ -295,12 +295,33 @@ const DEVICE_POLL_INTERVAL = 5             // 5 seconds
 // OAuthProvider
 // ============================================================================
 
+/**
+ * Audit event emitter callback used by the OAuthProvider to record
+ * trusted-account flow events (ADR-0007 BLOCKER 2). Fire-and-forget —
+ * implementations must not throw, and the provider treats failures as
+ * non-fatal. When unset, the provider emits nothing.
+ *
+ * In production, the worker passes `oauthStub.auditEvent` here; the stub
+ * forwards to AuditService which writes immutable `audit:*` rows in the
+ * shared OAuth DO shard. In tests, callers may pass a vi.fn() to capture
+ * emissions.
+ */
+export type OAuthAuditEmit = (event: {
+  event: string
+  actor?: string
+  target?: string
+  metadata?: Record<string, unknown>
+  ip?: string
+  userAgent?: string
+}) => Promise<void> | void
+
 export class OAuthProvider {
   private storage: StorageLike
   private config: OAuthConfig
   private getIdentity: (id: string) => Promise<IdentityInfo | null>
   private signingKeyManager?: SigningKeyManager
   private trustedAccount?: TrustedAccountConfig
+  private auditEmit?: OAuthAuditEmit
 
   get issuer(): string {
     return this.config.issuer
@@ -327,12 +348,21 @@ export class OAuthProvider {
     signingKeyManager?: SigningKeyManager
     /** ADR-0007: trusted-account OAuth mode for in-CF-account consumers. */
     trustedAccount?: TrustedAccountConfig
+    /**
+     * ADR-0007 (BLOCKER 2): callback to record audit events for trusted-
+     * account flow. Currently the provider emits `oauth.code.issued` and
+     * `oauth.token.issued` only on the trusted-account code paths, since
+     * those use one shared canonical client_id and would otherwise have
+     * no per-request traceability. DCR'd clients are intentionally untouched.
+     */
+    auditEmit?: OAuthAuditEmit
   }) {
     this.storage = options.storage
     this.config = options.config
     this.getIdentity = options.getIdentity
     this.signingKeyManager = options.signingKeyManager
     this.trustedAccount = options.trustedAccount
+    this.auditEmit = options.auditEmit
   }
 
   // ═══════════════════════════════════════════════════════════════════════════
@@ -1059,6 +1089,13 @@ export class OAuthProvider {
     await this.storage.delete(`code:${code}`)
 
     // ── Issue tokens ────────────────────────────────────────────────────
+    // ADR-0007 (BLOCKER 2): forward the consumer host to issueTokenPair so
+    // its `oauth.token.issued` audit event can record it. Computed from the
+    // redirect_uri the code was bound to (already verified above).
+    const redirectUriHost = this.isTrustedAccountClient(clientId)
+      ? this.extractRedirectUriHost(codeData.redirectUri)
+      : undefined
+
     return this.issueTokenPair({
       clientId,
       identityId: codeData.identityId,
@@ -1066,6 +1103,7 @@ export class OAuthProvider {
       nonce: codeData.nonce,
       resource: codeData.resource,
       effectiveIssuer: codeData.effectiveIssuer,
+      redirectUriHost,
     })
   }
 
@@ -1276,6 +1314,24 @@ export class OAuthProvider {
       expirationTtl: AUTH_CODE_TTL + 60,
     })
 
+    // ADR-0007 (BLOCKER 2): trace which consumer host produced this code.
+    // DCR'd clients are intentionally untouched — traceability for them is
+    // still via the `client:{cid_*}` row. Trusted-account is the only case
+    // where one canonical client_id is reused across an unbounded host set.
+    if (this.isTrustedAccountClient(client.id)) {
+      await this.safeEmitAudit({
+        event: 'oauth.code.issued',
+        actor: identityId,
+        target: codeId,
+        metadata: {
+          clientId: client.id,
+          identityId,
+          redirectUriHost: this.extractRedirectUriHost(params.redirectUri),
+          scopes: params.scopes,
+        },
+      })
+    }
+
     const redirectUrl = new URL(params.redirectUri)
     redirectUrl.searchParams.set('code', codeId)
     if (params.state) {
@@ -1283,6 +1339,39 @@ export class OAuthProvider {
     }
 
     return Response.redirect(redirectUrl.toString(), 302)
+  }
+
+  /**
+   * Extract the bare hostname from a redirect_uri, or undefined if the URI
+   * doesn't parse. Used for audit-event `redirectUriHost` (ADR-0007 BLOCKER 2).
+   */
+  private extractRedirectUriHost(redirectUri: string): string | undefined {
+    try {
+      return new URL(redirectUri).hostname
+    } catch {
+      return undefined
+    }
+  }
+
+  /**
+   * Fire-and-forget audit emission. Wraps the optional auditEmit callback
+   * in a try/catch so a downstream sink failure can never break the OAuth
+   * flow. Mirrors `worker/utils/audit.ts#logAuditEvent` semantics.
+   */
+  private async safeEmitAudit(event: {
+    event: string
+    actor?: string
+    target?: string
+    metadata?: Record<string, unknown>
+    ip?: string
+    userAgent?: string
+  }): Promise<void> {
+    if (!this.auditEmit) return
+    try {
+      await this.auditEmit(event)
+    } catch {
+      // never break the request flow for an audit failure
+    }
   }
 
   private async issueTokenPair(options: {
@@ -1293,8 +1382,14 @@ export class OAuthProvider {
     nonce?: string
     resource?: string
     effectiveIssuer?: string
+    /**
+     * ADR-0007 (BLOCKER 2): consumer's redirect_uri host, captured for the
+     * `oauth.token.issued` audit event metadata. Trusted-account flows only;
+     * ignored for everything else.
+     */
+    redirectUriHost?: string
   }): Promise<Response> {
-    const { clientId, identityId, scopes, family, nonce, resource, effectiveIssuer } = options
+    const { clientId, identityId, scopes, family, nonce, resource, effectiveIssuer, redirectUriHost } = options
     const now = Date.now()
     const accessTokenId = generateId('at_')
     const refreshTokenId = generateId('rt_')
@@ -1329,6 +1424,23 @@ export class OAuthProvider {
     await this.storage.put(`refresh:${refreshTokenId}`, refreshToken, {
       expirationTtl: REFRESH_TOKEN_TTL + 60,
     })
+
+    // ADR-0007 (BLOCKER 2): emit token-issuance audit for trusted-account
+    // flows. Trace points: access token id, refresh token id, consumer host.
+    if (this.isTrustedAccountClient(clientId)) {
+      await this.safeEmitAudit({
+        event: 'oauth.token.issued',
+        actor: identityId,
+        target: accessTokenId,
+        metadata: {
+          clientId,
+          identityId,
+          redirectUriHost,
+          refreshTokenId,
+          scopes,
+        },
+      })
+    }
 
     // Mint OIDC id_token when openid scope is granted and signing is available
     let idToken: string | undefined

--- a/test/oauth-routes-trusted-account.test.ts
+++ b/test/oauth-routes-trusted-account.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Route-level integration tests for the trusted-account OAuth flow (ADR-0007).
+ *
+ * Unlike `oauth-trusted-account.test.ts` which exercises the OAuthProvider
+ * class directly, this file mounts the real `worker/routes/oauth.ts` Hono
+ * sub-app and drives requests through `app.fetch`. The point is to cover the
+ * route-shell behavior — specifically CSRF state wrapping and audit emission —
+ * that the unit tests by-design cannot see.
+ *
+ * Coverage:
+ *   1. BLOCKER 1 (PR #8 review): GET /oauth/authorize with the canonical
+ *      trusted-account client_id must NOT wrap the incoming `state` query
+ *      parameter in a CSRF-bearing envelope. The redirect Location must carry
+ *      the original state verbatim, otherwise better-auth on the consumer
+ *      side rejects the callback. Mirrors commit 08abc13 (which fixed the
+ *      same class of failure for service-binding callers via X-Issuer).
+ *
+ *   2. BLOCKER 2 (PR #8 review): A successful trusted-account
+ *      authorize + token flow emits `oauth.code.issued` and
+ *      `oauth.token.issued` audit events; non-trusted clients do not.
+ *
+ * See: docs/adr/0007-trusted-account-oauth-via-better-auth.md
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { Hono } from 'hono'
+import { oauthRoutes, TRUSTED_ACCOUNT_CLIENT_ID } from '../worker/routes/oauth'
+import type { Env, Variables } from '../worker/types'
+import type { IdentityStub } from '../src/server/do/Identity'
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+async function computeS256Challenge(verifier: string): Promise<string> {
+  const data = new TextEncoder().encode(verifier)
+  const hash = await crypto.subtle.digest('SHA-256', data)
+  return btoa(String.fromCharCode(...new Uint8Array(hash)))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '')
+}
+
+/**
+ * Build a minimal env with an in-memory IDENTITY DO namespace stub. The DO
+ * is sharded by name; we route every name through a single shared in-memory
+ * store, which is sufficient for these tests (oauth storage + identity
+ * lookup share the same surface here).
+ */
+function createMockEnv(opts: { trustedDomains?: string } = {}): {
+  env: Env
+  oauthStore: Map<string, unknown>
+  identities: Map<string, { id: string; name?: string; email?: string; emailVerified?: boolean }>
+  auditEvents: Array<{ event: string; actor?: string; target?: string; metadata?: Record<string, unknown>; ip?: string; userAgent?: string }>
+} {
+  const oauthStore = new Map<string, unknown>()
+  const identities = new Map<string, { id: string; name?: string; email?: string; emailVerified?: boolean }>([
+    ['user-1', { id: 'user-1', name: 'Alice', email: 'alice@example.com', emailVerified: true }],
+  ])
+  const auditEvents: Array<{ event: string; actor?: string; target?: string; metadata?: Record<string, unknown>; ip?: string; userAgent?: string }> = []
+
+  const stub: Partial<IdentityStub> = {
+    getIdentity: vi.fn(async (id: string) => (identities.get(id) ?? null) as never),
+    // Used by authenticateRequest → AuthBroker. We expose user-1 as a valid
+    // session so the route receives `c.get('auth')` with `identityId: 'user-1'`.
+    getSession: vi.fn(async (token: string) => {
+      // The broker extracts `ses_*` from `Authorization: Bearer ses_*` and
+      // passes the remainder (after stripping `Bearer `) to getSession.
+      if (token === 'ses_user_1_session') {
+        return { valid: true, identityId: 'user-1', level: 2 } as never
+      }
+      return { valid: false } as never
+    }),
+    validateApiKey: vi.fn(async () => ({ valid: false }) as never),
+    checkRateLimit: vi.fn(async () => ({ allowed: true, remaining: 100, resetAt: Date.now() + 60000 }) as never),
+    ensureWebClients: vi.fn(async () => {}),
+    ensureCliClient: vi.fn(async () => {}),
+    ensureOAuthDoClient: vi.fn(async () => {}),
+    oauthStorageOp: vi.fn(async (op: { op: string; key?: string; value?: unknown; options?: { prefix?: string; limit?: number } }) => {
+      if (op.op === 'get' && op.key) {
+        return { value: oauthStore.get(op.key) }
+      }
+      if (op.op === 'put' && op.key) {
+        oauthStore.set(op.key, op.value)
+        return { ok: true }
+      }
+      if (op.op === 'delete' && op.key) {
+        return { deleted: oauthStore.delete(op.key) }
+      }
+      if (op.op === 'list') {
+        const entries: Array<[string, unknown]> = []
+        for (const [k, v] of oauthStore) {
+          if (op.options?.prefix && !k.startsWith(op.options.prefix)) continue
+          entries.push([k, v])
+        }
+        return { entries }
+      }
+      return {}
+    }),
+    auditEvent: vi.fn(async (e: { event: string; actor?: string; target?: string; metadata?: Record<string, unknown>; ip?: string; userAgent?: string }) => {
+      auditEvents.push(e)
+    }),
+  }
+
+  const env: Env = {
+    IDENTITY: {
+      // idFromName/get → always return the same stub. Sharding is invisible
+      // here because we route everything to one in-memory store.
+      idFromName: () => ({ toString: () => 'mock-id' } as unknown as DurableObjectId),
+      get: () => stub as unknown as DurableObjectStub,
+    } as unknown as DurableObjectNamespace,
+    SESSIONS: {} as KVNamespace,
+    AUTH_SECRET: 'test-secret',
+    JWKS_SECRET: 'test-jwks-secret',
+    ...(opts.trustedDomains !== undefined && { TRUSTED_ACCOUNT_DOMAINS: opts.trustedDomains }),
+  }
+
+  return { env, oauthStore, identities, auditEvents }
+}
+
+/**
+ * Mount the oauthRoutes sub-app with the identity stub pre-bound so the
+ * route's `authenticateRequest` middleware resolves a real identity. We
+ * pass a session token in tests; the stub's `getSession` returns user-1.
+ */
+function mountApp(env: Env) {
+  const app = new Hono<{ Bindings: Env; Variables: Variables }>()
+  app.use('*', async (c, next) => {
+    // Mimic worker/middleware/tenant.ts#identityStubMiddleware: pre-bind the
+    // identity-specific stub before authenticateRequest runs.
+    const stub = env.IDENTITY.get(env.IDENTITY.idFromName('user-1')) as unknown as IdentityStub
+    c.set('identityStub', stub)
+    c.set('resolvedIdentityId', 'user-1')
+    await next()
+  })
+  app.route('', oauthRoutes)
+  return app
+}
+
+/** Build a Bearer Authorization header that the broker's session path accepts. */
+const TEST_SESSION_HEADERS = { authorization: 'Bearer ses_user_1_session' }
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('worker/routes/oauth — trusted-account /oauth/authorize (ADR-0007 / BLOCKER 1)', () => {
+  let env: Env
+
+  beforeEach(() => {
+    ;({ env } = createMockEnv({ trustedDomains: 'startup.games' }))
+  })
+
+  it('does NOT wrap the state parameter when client_id is the trusted-account client', async () => {
+    const app = mountApp(env)
+    const codeChallenge = await computeS256Challenge('verifier-1234567890abcdef')
+
+    const url = new URL('https://id.org.ai/oauth/authorize')
+    url.searchParams.set('client_id', TRUSTED_ACCOUNT_CLIENT_ID)
+    url.searchParams.set('redirect_uri', 'https://startup.games/api/auth/callback/id-org-ai')
+    url.searchParams.set('response_type', 'code')
+    url.searchParams.set('scope', 'openid profile email')
+    url.searchParams.set('code_challenge', codeChallenge)
+    url.searchParams.set('code_challenge_method', 'S256')
+    url.searchParams.set('state', 'ORIGINAL_STATE')
+
+    const res = await app.fetch(
+      new Request(url.toString(), { method: 'GET', redirect: 'manual', headers: TEST_SESSION_HEADERS }),
+      env,
+    )
+
+    expect(res.status).toBe(302)
+    const location = res.headers.get('location')!
+    expect(location).toBeTruthy()
+    const locUrl = new URL(location)
+    expect(locUrl.hostname).toBe('startup.games')
+    expect(locUrl.pathname).toBe('/api/auth/callback/id-org-ai')
+
+    // The state must round-trip verbatim. If CSRF wrapping leaked through,
+    // the value would be a base64-encoded {csrf, s: 'ORIGINAL_STATE'} blob.
+    const returnedState = locUrl.searchParams.get('state')
+    expect(returnedState).toBe('ORIGINAL_STATE')
+    expect(returnedState).not.toMatch(/^[A-Za-z0-9_-]{40,}$/) // sanity: not a long base64ish blob
+
+    // A code should also be present, since trusted clients skip consent.
+    expect(locUrl.searchParams.get('code')).toMatch(/^ac_/)
+  })
+
+  it('still wraps state for ordinary (non-trusted, non-service-binding) clients', async () => {
+    // Seed a DCR-style client so the request gets past the client lookup.
+    const { env: envWithClient, oauthStore } = createMockEnv({ trustedDomains: 'startup.games' })
+    oauthStore.set('client:cid_some_normal_app', {
+      id: 'cid_some_normal_app',
+      name: 'Some Normal App',
+      redirectUris: ['https://normal-app.example.com/cb'],
+      grantTypes: ['authorization_code'],
+      responseTypes: ['code'],
+      scopes: ['openid', 'profile', 'email'],
+      trusted: false,
+      tokenEndpointAuthMethod: 'none',
+      createdAt: 0,
+    })
+    const app = mountApp(envWithClient)
+    const codeChallenge = await computeS256Challenge('verifier-1234567890abcdef')
+
+    const url = new URL('https://id.org.ai/oauth/authorize')
+    url.searchParams.set('client_id', 'cid_some_normal_app')
+    url.searchParams.set('redirect_uri', 'https://normal-app.example.com/cb')
+    url.searchParams.set('response_type', 'code')
+    url.searchParams.set('scope', 'openid')
+    url.searchParams.set('code_challenge', codeChallenge)
+    url.searchParams.set('code_challenge_method', 'S256')
+    url.searchParams.set('state', 'ORIGINAL_STATE')
+
+    const res = await app.fetch(
+      new Request(url.toString(), { method: 'GET', redirect: 'manual', headers: TEST_SESSION_HEADERS }),
+      envWithClient,
+    )
+
+    // The DCR client is not trusted, so the response is the consent HTML page,
+    // not a redirect. We only care here that the state we'd echo back to the
+    // consumer would be a wrapped value if the consent page were to be
+    // submitted — that's the path 08abc13 already handles via decodeStateWithCSRF.
+    expect(res.status).toBe(200)
+    const html = await res.text()
+    // The consent form embeds the (wrapped) state in a hidden input.
+    expect(html).toContain('<input type="hidden" name="state"')
+    // The original state value must NOT appear verbatim — it's CSRF-wrapped.
+    expect(html).not.toContain('value="ORIGINAL_STATE"')
+  })
+})

--- a/test/oauth-routes-trusted-account.test.ts
+++ b/test/oauth-routes-trusted-account.test.ts
@@ -182,6 +182,33 @@ describe('worker/routes/oauth — trusted-account /oauth/authorize (ADR-0007 / B
     expect(locUrl.searchParams.get('code')).toMatch(/^ac_/)
   })
 
+  it('emits oauth.code.issued via the IdentityDO stub when the trusted-account client receives a code (BLOCKER 2)', async () => {
+    const { env: env2, auditEvents } = createMockEnv({ trustedDomains: 'startup.games' })
+    const app = mountApp(env2)
+    const codeChallenge = await computeS256Challenge('verifier-1234567890abcdef')
+
+    const url = new URL('https://id.org.ai/oauth/authorize')
+    url.searchParams.set('client_id', TRUSTED_ACCOUNT_CLIENT_ID)
+    url.searchParams.set('redirect_uri', 'https://startup.games/api/auth/callback/id-org-ai')
+    url.searchParams.set('response_type', 'code')
+    url.searchParams.set('scope', 'openid profile email')
+    url.searchParams.set('code_challenge', codeChallenge)
+    url.searchParams.set('code_challenge_method', 'S256')
+    url.searchParams.set('state', 'ORIGINAL_STATE')
+
+    const res = await app.fetch(
+      new Request(url.toString(), { method: 'GET', redirect: 'manual', headers: TEST_SESSION_HEADERS }),
+      env2,
+    )
+    expect(res.status).toBe(302)
+
+    const codeEvents = auditEvents.filter((e) => e.event === 'oauth.code.issued')
+    expect(codeEvents).toHaveLength(1)
+    expect(codeEvents[0].metadata?.clientId).toBe(TRUSTED_ACCOUNT_CLIENT_ID)
+    expect(codeEvents[0].metadata?.identityId).toBe('user-1')
+    expect(codeEvents[0].metadata?.redirectUriHost).toBe('startup.games')
+  })
+
   it('still wraps state for ordinary (non-trusted, non-service-binding) clients', async () => {
     // Seed a DCR-style client so the request gets past the client lookup.
     const { env: envWithClient, oauthStore } = createMockEnv({ trustedDomains: 'startup.games' })

--- a/test/oauth-trusted-account.test.ts
+++ b/test/oauth-trusted-account.test.ts
@@ -1,0 +1,426 @@
+/**
+ * Trusted-Account OAuth Mode (ADR-0007)
+ *
+ * Verifies the issuer-side relaxation:
+ *   - The canonical shared client_id `cid_trusted_account_v1` bypasses DCR
+ *     entirely. Its redirect_uri list is implicit-via-allowlist.
+ *   - PKCE, scope, state validation are unchanged.
+ *   - Non-trusted client_ids still hit the existing DCR path unchanged.
+ *
+ * See: docs/adr/0007-trusted-account-oauth-via-better-auth.md
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { OAuthProvider } from '../src/sdk/oauth/provider'
+import type { OAuthConfig } from '../src/sdk/oauth/provider'
+import {
+  parseTrustedAccountDomains,
+  TRUSTED_ACCOUNT_CLIENT_ID,
+} from '../worker/routes/oauth'
+
+// ── Mirror the storage helper used by the broader OAuth tests ───────────────
+
+type StorageLike = {
+  get<T = unknown>(key: string): Promise<T | undefined>
+  put(key: string, value: unknown, options?: { expirationTtl?: number }): Promise<void>
+  delete(key: string): Promise<boolean>
+  list<T = unknown>(options?: { prefix?: string; limit?: number }): Promise<Map<string, T>>
+}
+
+function createMockStorage(): StorageLike {
+  const store = new Map<string, unknown>()
+  return {
+    async get<T = unknown>(key: string): Promise<T | undefined> {
+      return store.get(key) as T | undefined
+    },
+    async put(key: string, value: unknown): Promise<void> {
+      store.set(key, value)
+    },
+    async delete(key: string): Promise<boolean> {
+      return store.delete(key)
+    },
+    async list<T = unknown>(options?: { prefix?: string; limit?: number }): Promise<Map<string, T>> {
+      const result = new Map<string, T>()
+      let count = 0
+      for (const [key, value] of store) {
+        if (options?.prefix && !key.startsWith(options.prefix)) continue
+        if (options?.limit && count >= options.limit) break
+        result.set(key, value as T)
+        count++
+      }
+      return result
+    },
+  }
+}
+
+const TEST_CONFIG: OAuthConfig = {
+  issuer: 'https://id.org.ai',
+  authorizationEndpoint: 'https://id.org.ai/oauth/authorize',
+  tokenEndpoint: 'https://id.org.ai/oauth/token',
+  userinfoEndpoint: 'https://id.org.ai/oauth/userinfo',
+  registrationEndpoint: 'https://id.org.ai/oauth/register',
+  deviceAuthorizationEndpoint: 'https://id.org.ai/oauth/device',
+  revocationEndpoint: 'https://id.org.ai/oauth/revoke',
+  introspectionEndpoint: 'https://id.org.ai/oauth/introspect',
+  jwksUri: 'https://id.org.ai/.well-known/jwks.json',
+}
+
+const TRUSTED_CLIENT_ID = TRUSTED_ACCOUNT_CLIENT_ID
+
+const TEST_IDENTITIES: Record<string, { id: string; name?: string; email?: string; emailVerified?: boolean }> = {
+  'user-1': {
+    id: 'user-1',
+    name: 'Alice',
+    email: 'alice@example.com',
+    emailVerified: true,
+  },
+}
+
+function createTrustedProvider(allowedDomains: string[], storage?: StorageLike): OAuthProvider {
+  return new OAuthProvider({
+    storage: storage ?? createMockStorage(),
+    config: TEST_CONFIG,
+    getIdentity: async (id: string) => TEST_IDENTITIES[id] ?? null,
+    trustedAccount: {
+      clientId: TRUSTED_CLIENT_ID,
+      allowedDomains: new Set(allowedDomains),
+    },
+  })
+}
+
+function createUntrustedProvider(storage?: StorageLike): OAuthProvider {
+  return new OAuthProvider({
+    storage: storage ?? createMockStorage(),
+    config: TEST_CONFIG,
+    getIdentity: async (id: string) => TEST_IDENTITIES[id] ?? null,
+    // No trustedAccount config - should behave exactly like before.
+  })
+}
+
+async function computeS256Challenge(verifier: string): Promise<string> {
+  const data = new TextEncoder().encode(verifier)
+  const hash = await crypto.subtle.digest('SHA-256', data)
+  return btoa(String.fromCharCode(...new Uint8Array(hash)))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '')
+}
+
+function buildAuthorizeUrl(params: Record<string, string>): string {
+  const url = new URL('https://id.org.ai/oauth/authorize')
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v)
+  return url.toString()
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('parseTrustedAccountDomains', () => {
+  it('returns an empty set for undefined or empty input', () => {
+    expect(parseTrustedAccountDomains(undefined).size).toBe(0)
+    expect(parseTrustedAccountDomains('').size).toBe(0)
+    expect(parseTrustedAccountDomains('   ').size).toBe(0)
+  })
+
+  it('parses comma-separated bare hostnames and lowercases them', () => {
+    const set = parseTrustedAccountDomains('startup.games, Foo.Example , bar.test')
+    expect(set.has('startup.games')).toBe(true)
+    expect(set.has('foo.example')).toBe(true)
+    expect(set.has('bar.test')).toBe(true)
+    expect(set.size).toBe(3)
+  })
+
+  it('rejects entries that look like URLs (scheme, port, path)', () => {
+    const set = parseTrustedAccountDomains('https://evil.com, ok.com, has space, port.com:8080, with/path')
+    expect(set.has('ok.com')).toBe(true)
+    // The above all contain characters we reject defensively.
+    expect(set.has('https://evil.com')).toBe(false)
+    expect(set.has('has space')).toBe(false)
+    expect(set.has('port.com:8080')).toBe(false)
+    expect(set.has('with/path')).toBe(false)
+    expect(set.size).toBe(1)
+  })
+})
+
+describe('OAuthProvider - trusted-account mode (ADR-0007)', () => {
+  let storage: StorageLike
+
+  beforeEach(() => {
+    storage = createMockStorage()
+  })
+
+  // ── /oauth/authorize ──────────────────────────────────────────────────────
+
+  describe('/oauth/authorize', () => {
+    it('accepts trusted-account client + allowlisted redirect_uri and returns a code', async () => {
+      const provider = createTrustedProvider(['startup.games'], storage)
+      const codeChallenge = await computeS256Challenge('verifier-1234567890abcdef')
+
+      const url = buildAuthorizeUrl({
+        client_id: TRUSTED_CLIENT_ID,
+        redirect_uri: 'https://startup.games/api/auth/callback/id-org-ai',
+        response_type: 'code',
+        scope: 'openid profile email',
+        code_challenge: codeChallenge,
+        code_challenge_method: 'S256',
+        state: 'test-state',
+      })
+      const req = new Request(url, { method: 'GET', redirect: 'manual' })
+      const res = await provider.handleAuthorize(req, 'user-1')
+
+      expect(res.status).toBe(302)
+      const location = new URL(res.headers.get('location')!)
+      expect(location.host).toBe('startup.games')
+      expect(location.pathname).toBe('/api/auth/callback/id-org-ai')
+      expect(location.searchParams.get('code')).toMatch(/^ac_/)
+      expect(location.searchParams.get('state')).toBe('test-state')
+      expect(location.searchParams.get('error')).toBeNull()
+    })
+
+    it('accepts allowlisted host on a sub-path/query', async () => {
+      const provider = createTrustedProvider(['startup.games'])
+      const codeChallenge = await computeS256Challenge('verifier-1234567890abcdef')
+      const url = buildAuthorizeUrl({
+        client_id: TRUSTED_CLIENT_ID,
+        redirect_uri: 'https://startup.games/some/other/path?x=1',
+        response_type: 'code',
+        scope: 'openid',
+        code_challenge: codeChallenge,
+        code_challenge_method: 'S256',
+      })
+      const res = await provider.handleAuthorize(new Request(url, { method: 'GET', redirect: 'manual' }), 'user-1')
+      expect(res.status).toBe(302)
+      expect(new URL(res.headers.get('location')!).host).toBe('startup.games')
+    })
+
+    it('rejects trusted-account client + non-allowlisted redirect_uri with 400', async () => {
+      const provider = createTrustedProvider(['startup.games'])
+      const codeChallenge = await computeS256Challenge('verifier-1234567890abcdef')
+      const url = buildAuthorizeUrl({
+        client_id: TRUSTED_CLIENT_ID,
+        redirect_uri: 'https://evil.example.com/callback',
+        response_type: 'code',
+        scope: 'openid',
+        code_challenge: codeChallenge,
+        code_challenge_method: 'S256',
+      })
+      const res = await provider.handleAuthorize(new Request(url, { method: 'GET', redirect: 'manual' }), 'user-1')
+
+      expect(res.status).toBe(400)
+      const body = (await res.json()) as { error: string; error_description: string }
+      expect(body.error).toBe('invalid_request')
+      expect(body.error_description).toMatch(/trusted-account allowlist/i)
+    })
+
+    it('rejects subdomain when only the apex is allowlisted (exact host match)', async () => {
+      const provider = createTrustedProvider(['startup.games'])
+      const codeChallenge = await computeS256Challenge('verifier-1234567890abcdef')
+      const url = buildAuthorizeUrl({
+        client_id: TRUSTED_CLIENT_ID,
+        redirect_uri: 'https://app.startup.games/cb',
+        response_type: 'code',
+        scope: 'openid',
+        code_challenge: codeChallenge,
+        code_challenge_method: 'S256',
+      })
+      const res = await provider.handleAuthorize(new Request(url, { method: 'GET', redirect: 'manual' }), 'user-1')
+      expect(res.status).toBe(400)
+    })
+
+    it('rejects http (non-https) redirect_uri even when host is allowlisted', async () => {
+      const provider = createTrustedProvider(['startup.games'])
+      const codeChallenge = await computeS256Challenge('verifier-1234567890abcdef')
+      const url = buildAuthorizeUrl({
+        client_id: TRUSTED_CLIENT_ID,
+        redirect_uri: 'http://startup.games/cb',
+        response_type: 'code',
+        scope: 'openid',
+        code_challenge: codeChallenge,
+        code_challenge_method: 'S256',
+      })
+      const res = await provider.handleAuthorize(new Request(url, { method: 'GET', redirect: 'manual' }), 'user-1')
+      expect(res.status).toBe(400)
+    })
+
+    it('still requires PKCE for the trusted-account public client', async () => {
+      const provider = createTrustedProvider(['startup.games'])
+      const url = buildAuthorizeUrl({
+        client_id: TRUSTED_CLIENT_ID,
+        redirect_uri: 'https://startup.games/cb',
+        response_type: 'code',
+        scope: 'openid',
+        // no code_challenge
+      })
+      const res = await provider.handleAuthorize(new Request(url, { method: 'GET', redirect: 'manual' }), 'user-1')
+      // PKCE failure is reported via redirect (302) with error=invalid_request
+      expect(res.status).toBe(302)
+      const location = new URL(res.headers.get('location')!)
+      expect(location.searchParams.get('error')).toBe('invalid_request')
+      expect(location.searchParams.get('error_description')).toMatch(/code_challenge/i)
+    })
+
+    it('non-trusted client_id still hits the DCR path unchanged (unknown client -> 400)', async () => {
+      const provider = createTrustedProvider(['startup.games'], storage)
+      const codeChallenge = await computeS256Challenge('verifier-1234567890abcdef')
+      const url = buildAuthorizeUrl({
+        // not the trusted client id; nothing is in storage for this id
+        client_id: 'cid_some_unknown_app',
+        redirect_uri: 'https://startup.games/cb',
+        response_type: 'code',
+        scope: 'openid',
+        code_challenge: codeChallenge,
+        code_challenge_method: 'S256',
+      })
+      const res = await provider.handleAuthorize(new Request(url, { method: 'GET', redirect: 'manual' }), 'user-1')
+      expect(res.status).toBe(400)
+      const body = (await res.json()) as { error: string }
+      expect(body.error).toBe('invalid_client')
+    })
+
+    it('without trustedAccount config, the canonical client_id is rejected as unknown', async () => {
+      const provider = createUntrustedProvider(storage)
+      const codeChallenge = await computeS256Challenge('verifier-1234567890abcdef')
+      const url = buildAuthorizeUrl({
+        client_id: TRUSTED_CLIENT_ID,
+        redirect_uri: 'https://startup.games/cb',
+        response_type: 'code',
+        scope: 'openid',
+        code_challenge: codeChallenge,
+        code_challenge_method: 'S256',
+      })
+      const res = await provider.handleAuthorize(new Request(url, { method: 'GET', redirect: 'manual' }), 'user-1')
+      expect(res.status).toBe(400)
+      const body = (await res.json()) as { error: string }
+      expect(body.error).toBe('invalid_client')
+    })
+  })
+
+  // ── /oauth/token ──────────────────────────────────────────────────────────
+
+  describe('/oauth/token', () => {
+    async function getCodeForTrusted(
+      provider: OAuthProvider,
+      redirectUri: string,
+      codeVerifier: string,
+    ): Promise<string> {
+      const codeChallenge = await computeS256Challenge(codeVerifier)
+      const url = buildAuthorizeUrl({
+        client_id: TRUSTED_CLIENT_ID,
+        redirect_uri: redirectUri,
+        response_type: 'code',
+        scope: 'openid profile email',
+        code_challenge: codeChallenge,
+        code_challenge_method: 'S256',
+        state: 'st-1',
+      })
+      const res = await provider.handleAuthorize(
+        new Request(url, { method: 'GET', redirect: 'manual' }),
+        'user-1',
+      )
+      return new URL(res.headers.get('location')!).searchParams.get('code')!
+    }
+
+    it('exchanges code -> tokens for trusted-account client with no client_secret', async () => {
+      const provider = createTrustedProvider(['startup.games'], storage)
+      const redirectUri = 'https://startup.games/api/auth/callback/id-org-ai'
+      const verifier = 'verifier-1234567890abcdef'
+      const code = await getCodeForTrusted(provider, redirectUri, verifier)
+
+      const tokenReq = new Request('https://id.org.ai/oauth/token', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          grant_type: 'authorization_code',
+          code,
+          redirect_uri: redirectUri,
+          client_id: TRUSTED_CLIENT_ID,
+          code_verifier: verifier,
+          // intentionally no client_secret
+        }),
+      })
+      const res = await provider.handleToken(tokenReq)
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as Record<string, unknown>
+      expect(body.access_token).toMatch(/^at_/)
+      expect(body.refresh_token).toMatch(/^rt_/)
+      expect(body.token_type).toBe('Bearer')
+      expect(body.scope).toBe('openid profile email')
+    })
+
+    it('rejects token exchange if the allowlist no longer contains the host', async () => {
+      const provider = createTrustedProvider(['startup.games'], storage)
+      const redirectUri = 'https://startup.games/api/auth/callback/id-org-ai'
+      const verifier = 'verifier-1234567890abcdef'
+      const code = await getCodeForTrusted(provider, redirectUri, verifier)
+
+      // Simulate the allowlist shrinking between /authorize and /token by
+      // building a new provider with a different allowlist over the same store.
+      const shrunkProvider = createTrustedProvider(['someone-else.com'], storage)
+
+      const tokenReq = new Request('https://id.org.ai/oauth/token', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          grant_type: 'authorization_code',
+          code,
+          redirect_uri: redirectUri,
+          client_id: TRUSTED_CLIENT_ID,
+          code_verifier: verifier,
+        }),
+      })
+      const res = await shrunkProvider.handleToken(tokenReq)
+      expect(res.status).toBe(400)
+      const body = (await res.json()) as { error: string; error_description: string }
+      expect(body.error).toBe('invalid_grant')
+      expect(body.error_description).toMatch(/trusted-account allowlist/i)
+    })
+
+    it('rejects token exchange when redirect_uri body does not match the code', async () => {
+      const provider = createTrustedProvider(['startup.games'], storage)
+      const redirectUri = 'https://startup.games/api/auth/callback/id-org-ai'
+      const verifier = 'verifier-1234567890abcdef'
+      const code = await getCodeForTrusted(provider, redirectUri, verifier)
+
+      const tokenReq = new Request('https://id.org.ai/oauth/token', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          grant_type: 'authorization_code',
+          code,
+          // different path -> still allowlisted host, but mismatched against the code
+          redirect_uri: 'https://startup.games/different/path',
+          client_id: TRUSTED_CLIENT_ID,
+          code_verifier: verifier,
+        }),
+      })
+      const res = await provider.handleToken(tokenReq)
+      expect(res.status).toBe(400)
+      const body = (await res.json()) as { error: string }
+      expect(body.error).toBe('invalid_grant')
+    })
+
+    it('rejects token exchange with wrong code_verifier (PKCE still enforced)', async () => {
+      const provider = createTrustedProvider(['startup.games'], storage)
+      const redirectUri = 'https://startup.games/api/auth/callback/id-org-ai'
+      const verifier = 'verifier-1234567890abcdef'
+      const code = await getCodeForTrusted(provider, redirectUri, verifier)
+
+      const tokenReq = new Request('https://id.org.ai/oauth/token', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          grant_type: 'authorization_code',
+          code,
+          redirect_uri: redirectUri,
+          client_id: TRUSTED_CLIENT_ID,
+          code_verifier: 'wrong-verifier-1234567890abcdef',
+        }),
+      })
+      const res = await provider.handleToken(tokenReq)
+      expect(res.status).toBe(400)
+      const body = (await res.json()) as { error: string }
+      expect(body.error).toBe('invalid_grant')
+    })
+  })
+})

--- a/test/oauth-trusted-account.test.ts
+++ b/test/oauth-trusted-account.test.ts
@@ -429,6 +429,136 @@ describe('OAuthProvider - trusted-account mode (ADR-0007)', () => {
     })
   })
 
+  // ── /oauth/token refresh_token grant — ADR-0007 QUESTION resolution ───────
+
+  describe('/oauth/token refresh_token grant — allowlist re-check (ADR-0007 QUESTION)', () => {
+    async function exchangeForTokens(
+      provider: OAuthProvider,
+      redirectUri: string,
+    ): Promise<{ accessToken: string; refreshToken: string }> {
+      const verifier = 'verifier-1234567890abcdef'
+      const codeChallenge = await computeS256Challenge(verifier)
+      const url = buildAuthorizeUrl({
+        client_id: TRUSTED_CLIENT_ID,
+        redirect_uri: redirectUri,
+        response_type: 'code',
+        scope: 'openid profile email offline_access',
+        code_challenge: codeChallenge,
+        code_challenge_method: 'S256',
+      })
+      const authRes = await provider.handleAuthorize(
+        new Request(url, { method: 'GET', redirect: 'manual' }),
+        'user-1',
+      )
+      const code = new URL(authRes.headers.get('location')!).searchParams.get('code')!
+
+      const tokenRes = await provider.handleToken(
+        new Request('https://id.org.ai/oauth/token', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: new URLSearchParams({
+            grant_type: 'authorization_code',
+            code,
+            redirect_uri: redirectUri,
+            client_id: TRUSTED_CLIENT_ID,
+            code_verifier: verifier,
+          }),
+        }),
+      )
+      const body = (await tokenRes.json()) as { access_token: string; refresh_token: string }
+      return { accessToken: body.access_token, refreshToken: body.refresh_token }
+    }
+
+    it('refresh succeeds while the consumer host is still allowlisted', async () => {
+      const provider = createTrustedProvider(['startup.games'], storage)
+      const { refreshToken } = await exchangeForTokens(
+        provider,
+        'https://startup.games/api/auth/callback/id-org-ai',
+      )
+
+      const res = await provider.handleToken(
+        new Request('https://id.org.ai/oauth/token', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: new URLSearchParams({
+            grant_type: 'refresh_token',
+            refresh_token: refreshToken,
+            client_id: TRUSTED_CLIENT_ID,
+          }),
+        }),
+      )
+
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as Record<string, unknown>
+      expect(body.access_token).toMatch(/^at_/)
+      expect(body.refresh_token).toMatch(/^rt_/)
+      // Rotation: the new refresh token is distinct from the original.
+      expect(body.refresh_token).not.toBe(refreshToken)
+    })
+
+    it('refresh fails closed when the allowlist shrinks between issuance and refresh', async () => {
+      const provider = createTrustedProvider(['startup.games'], storage)
+      const { refreshToken } = await exchangeForTokens(
+        provider,
+        'https://startup.games/api/auth/callback/id-org-ai',
+      )
+
+      // Allowlist shrinks: the same storage now sees a provider whose env
+      // no longer trusts 'startup.games'. Mirrors the existing
+      // authorization-code grant's "allowlist shrinks" test.
+      const shrunkProvider = createTrustedProvider(['someone-else.com'], storage)
+
+      const res = await shrunkProvider.handleToken(
+        new Request('https://id.org.ai/oauth/token', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: new URLSearchParams({
+            grant_type: 'refresh_token',
+            refresh_token: refreshToken,
+            client_id: TRUSTED_CLIENT_ID,
+          }),
+        }),
+      )
+
+      expect(res.status).toBe(400)
+      const body = (await res.json()) as { error: string; error_description: string }
+      expect(body.error).toBe('invalid_grant')
+      expect(body.error_description).toMatch(/trusted-account allowlist/i)
+    })
+
+    it('stores the consumer host on the issued refresh token', async () => {
+      const provider = createTrustedProvider(['startup.games'], storage)
+      const { refreshToken } = await exchangeForTokens(
+        provider,
+        'https://startup.games/api/auth/callback/id-org-ai',
+      )
+      const stored = await storage.get<{ consumerHost?: string }>(`refresh:${refreshToken}`)
+      expect(stored?.consumerHost).toBe('startup.games')
+    })
+
+    it('propagates the consumer host through rotation', async () => {
+      const provider = createTrustedProvider(['startup.games'], storage)
+      const { refreshToken } = await exchangeForTokens(
+        provider,
+        'https://startup.games/api/auth/callback/id-org-ai',
+      )
+      const res = await provider.handleToken(
+        new Request('https://id.org.ai/oauth/token', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: new URLSearchParams({
+            grant_type: 'refresh_token',
+            refresh_token: refreshToken,
+            client_id: TRUSTED_CLIENT_ID,
+          }),
+        }),
+      )
+      const body = (await res.json()) as { refresh_token: string }
+      const rotated = await storage.get<{ consumerHost?: string }>(`refresh:${body.refresh_token}`)
+      expect(rotated?.consumerHost).toBe('startup.games')
+    })
+  })
+
   // ── Audit emission — ADR-0007 BLOCKER 2 ───────────────────────────────────
 
   describe('audit emission (ADR-0007 BLOCKER 2)', () => {
@@ -481,6 +611,62 @@ describe('OAuthProvider - trusted-account mode (ADR-0007)', () => {
       expect(tokenEvents[0].metadata?.clientId).toBe(TRUSTED_CLIENT_ID)
       expect(tokenEvents[0].metadata?.identityId).toBe('user-1')
       expect(tokenEvents[0].metadata?.redirectUriHost).toBe('startup.games')
+    })
+
+    it('emits oauth.token.issued on refresh-token rotation for trusted-account clients', async () => {
+      const emit = vi.fn<Parameters<OAuthAuditEmit>, ReturnType<OAuthAuditEmit>>()
+      const provider = createTrustedProvider(['startup.games'], storage, emit)
+
+      const redirectUri = 'https://startup.games/api/auth/callback/id-org-ai'
+      const verifier = 'verifier-1234567890abcdef'
+      const codeChallenge = await computeS256Challenge(verifier)
+
+      const authUrl = buildAuthorizeUrl({
+        client_id: TRUSTED_CLIENT_ID,
+        redirect_uri: redirectUri,
+        response_type: 'code',
+        scope: 'openid profile email offline_access',
+        code_challenge: codeChallenge,
+        code_challenge_method: 'S256',
+      })
+      const authRes = await provider.handleAuthorize(
+        new Request(authUrl, { method: 'GET', redirect: 'manual' }),
+        'user-1',
+      )
+      const code = new URL(authRes.headers.get('location')!).searchParams.get('code')!
+
+      const initialTokenRes = await provider.handleToken(
+        new Request('https://id.org.ai/oauth/token', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: new URLSearchParams({
+            grant_type: 'authorization_code',
+            code,
+            redirect_uri: redirectUri,
+            client_id: TRUSTED_CLIENT_ID,
+            code_verifier: verifier,
+          }),
+        }),
+      )
+      const { refresh_token: refreshToken } = (await initialTokenRes.json()) as { refresh_token: string }
+
+      emit.mockClear()
+
+      await provider.handleToken(
+        new Request('https://id.org.ai/oauth/token', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: new URLSearchParams({
+            grant_type: 'refresh_token',
+            refresh_token: refreshToken,
+            client_id: TRUSTED_CLIENT_ID,
+          }),
+        }),
+      )
+
+      const refreshEvents = emit.mock.calls.map((c) => c[0]).filter((e) => e.event === 'oauth.token.issued')
+      expect(refreshEvents).toHaveLength(1)
+      expect(refreshEvents[0].metadata?.redirectUriHost).toBe('startup.games')
     })
 
     it('does NOT emit audit events for non-trusted clients (DCR path unchanged)', async () => {

--- a/test/oauth-trusted-account.test.ts
+++ b/test/oauth-trusted-account.test.ts
@@ -10,9 +10,9 @@
  * See: docs/adr/0007-trusted-account-oauth-via-better-auth.md
  */
 
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { OAuthProvider } from '../src/sdk/oauth/provider'
-import type { OAuthConfig } from '../src/sdk/oauth/provider'
+import type { OAuthConfig, OAuthAuditEmit } from '../src/sdk/oauth/provider'
 import {
   parseTrustedAccountDomains,
   TRUSTED_ACCOUNT_CLIENT_ID,
@@ -76,7 +76,11 @@ const TEST_IDENTITIES: Record<string, { id: string; name?: string; email?: strin
   },
 }
 
-function createTrustedProvider(allowedDomains: string[], storage?: StorageLike): OAuthProvider {
+function createTrustedProvider(
+  allowedDomains: string[],
+  storage?: StorageLike,
+  auditEmit?: OAuthAuditEmit,
+): OAuthProvider {
   return new OAuthProvider({
     storage: storage ?? createMockStorage(),
     config: TEST_CONFIG,
@@ -85,6 +89,7 @@ function createTrustedProvider(allowedDomains: string[], storage?: StorageLike):
       clientId: TRUSTED_CLIENT_ID,
       allowedDomains: new Set(allowedDomains),
     },
+    ...(auditEmit !== undefined && { auditEmit }),
   })
 }
 
@@ -421,6 +426,119 @@ describe('OAuthProvider - trusted-account mode (ADR-0007)', () => {
       expect(res.status).toBe(400)
       const body = (await res.json()) as { error: string }
       expect(body.error).toBe('invalid_grant')
+    })
+  })
+
+  // ── Audit emission — ADR-0007 BLOCKER 2 ───────────────────────────────────
+
+  describe('audit emission (ADR-0007 BLOCKER 2)', () => {
+    it('emits oauth.code.issued and oauth.token.issued for a successful trusted-account flow', async () => {
+      const emit = vi.fn<Parameters<OAuthAuditEmit>, ReturnType<OAuthAuditEmit>>()
+      const provider = createTrustedProvider(['startup.games'], storage, emit)
+
+      const redirectUri = 'https://startup.games/api/auth/callback/id-org-ai'
+      const verifier = 'verifier-1234567890abcdef'
+      const codeChallenge = await computeS256Challenge(verifier)
+
+      const authUrl = buildAuthorizeUrl({
+        client_id: TRUSTED_CLIENT_ID,
+        redirect_uri: redirectUri,
+        response_type: 'code',
+        scope: 'openid profile email',
+        code_challenge: codeChallenge,
+        code_challenge_method: 'S256',
+      })
+      const authRes = await provider.handleAuthorize(
+        new Request(authUrl, { method: 'GET', redirect: 'manual' }),
+        'user-1',
+      )
+      const code = new URL(authRes.headers.get('location')!).searchParams.get('code')!
+
+      // After /authorize, exactly one oauth.code.issued event must be present.
+      const codeEvents = emit.mock.calls.map((c) => c[0]).filter((e) => e.event === 'oauth.code.issued')
+      expect(codeEvents).toHaveLength(1)
+      expect(codeEvents[0].metadata?.clientId).toBe(TRUSTED_CLIENT_ID)
+      expect(codeEvents[0].metadata?.identityId).toBe('user-1')
+      expect(codeEvents[0].metadata?.redirectUriHost).toBe('startup.games')
+
+      // Exchange the code for tokens.
+      await provider.handleToken(
+        new Request('https://id.org.ai/oauth/token', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: new URLSearchParams({
+            grant_type: 'authorization_code',
+            code,
+            redirect_uri: redirectUri,
+            client_id: TRUSTED_CLIENT_ID,
+            code_verifier: verifier,
+          }),
+        }),
+      )
+
+      const tokenEvents = emit.mock.calls.map((c) => c[0]).filter((e) => e.event === 'oauth.token.issued')
+      expect(tokenEvents).toHaveLength(1)
+      expect(tokenEvents[0].metadata?.clientId).toBe(TRUSTED_CLIENT_ID)
+      expect(tokenEvents[0].metadata?.identityId).toBe('user-1')
+      expect(tokenEvents[0].metadata?.redirectUriHost).toBe('startup.games')
+    })
+
+    it('does NOT emit audit events for non-trusted clients (DCR path unchanged)', async () => {
+      const emit = vi.fn<Parameters<OAuthAuditEmit>, ReturnType<OAuthAuditEmit>>()
+      // Provider WITH a trusted-account config and an audit sink. We register
+      // a DCR'd public client whose redirect_uri matches one of the
+      // allowlisted hosts; this proves the audit emission is gated on
+      // `client_id === trustedAccount.clientId`, not on the redirect host.
+      const provider = createTrustedProvider(['app.example.com'], storage, emit)
+
+      const dcrClientId = 'cid_dcr_example_app'
+      await storage.put(`client:${dcrClientId}`, {
+        id: dcrClientId,
+        name: 'DCR Example App',
+        redirectUris: ['https://app.example.com/cb'],
+        grantTypes: ['authorization_code', 'refresh_token'],
+        responseTypes: ['code'],
+        scopes: ['openid', 'profile', 'email'],
+        trusted: true, // skip consent so the test can use handleAuthorize directly
+        tokenEndpointAuthMethod: 'none',
+        createdAt: 0,
+      })
+
+      const verifier = 'verifier-1234567890abcdef'
+      const codeChallenge = await computeS256Challenge(verifier)
+      const redirectUri = 'https://app.example.com/cb'
+
+      const authUrl = buildAuthorizeUrl({
+        client_id: dcrClientId,
+        redirect_uri: redirectUri,
+        response_type: 'code',
+        scope: 'openid',
+        code_challenge: codeChallenge,
+        code_challenge_method: 'S256',
+      })
+      const authRes = await provider.handleAuthorize(
+        new Request(authUrl, { method: 'GET', redirect: 'manual' }),
+        'user-1',
+      )
+      const code = new URL(authRes.headers.get('location')!).searchParams.get('code')!
+
+      await provider.handleToken(
+        new Request('https://id.org.ai/oauth/token', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: new URLSearchParams({
+            grant_type: 'authorization_code',
+            code,
+            redirect_uri: redirectUri,
+            client_id: dcrClientId,
+            code_verifier: verifier,
+          }),
+        }),
+      )
+
+      // No audit emissions for the DCR path — the BLOCKER 2 fix is gated
+      // strictly on `isTrustedAccountClient(clientId)`.
+      expect(emit).not.toHaveBeenCalled()
     })
   })
 })

--- a/worker/routes/oauth.ts
+++ b/worker/routes/oauth.ts
@@ -20,6 +20,33 @@ import { AUDIT_EVENTS } from '../../src/sdk/audit'
 
 const app = new Hono<{ Bindings: Env; Variables: Variables }>()
 
+// ── Trusted-Account OAuth (ADR-0007) ────────────────────────────────────────
+//
+// Canonical shared client_id for in-Cloudflare-account consumers. Any request
+// using this client_id is validated against the TRUSTED_ACCOUNT_DOMAINS env
+// allowlist instead of a per-app DCR `redirect_uris` array.
+//
+// We pick option (b) from ADR-0007: bypass the DCR lookup entirely rather
+// than provisioning a real `client:cid_trusted_account_v1` record. This keeps
+// the diff small (no one-time bootstrap endpoint, no seeding step) and the
+// virtual client's metadata is fully derivable from env config.
+export const TRUSTED_ACCOUNT_CLIENT_ID = 'cid_trusted_account_v1'
+
+/** Parse a comma-separated env value into a Set of bare hostnames. */
+export function parseTrustedAccountDomains(value: string | undefined): Set<string> {
+  const set = new Set<string>()
+  if (!value) return set
+  for (const raw of value.split(',')) {
+    const host = raw.trim().toLowerCase()
+    if (!host) continue
+    // Defensive: reject obvious mistakes (schemes, paths) so a typo in
+    // the env doesn't silently widen the trust boundary.
+    if (host.includes('/') || host.includes(':') || host.includes(' ')) continue
+    set.add(host)
+  }
+  return set
+}
+
 // ── Helper ──────────────────────────────────────────────────────────────────
 
 export function getOAuthProvider(c: any): OAuthProvider {
@@ -28,6 +55,7 @@ export function getOAuthProvider(c: any): OAuthProvider {
   const stub = getStubForIdentity(c.env, 'oauth')
   const signingKeyManager = getSigningKeyManager(c.env)
   const base = 'https://id.org.ai'
+  const allowedDomains = parseTrustedAccountDomains(c.env.TRUSTED_ACCOUNT_DOMAINS)
   return new OAuthProvider({
     storage: {
       async get<T = unknown>(key: string): Promise<T | undefined> {
@@ -65,6 +93,13 @@ export function getOAuthProvider(c: any): OAuthProvider {
       return identity as unknown as { id: string; name?: string; handle?: string; email?: string; emailVerified?: boolean; image?: string; level?: number }
     },
     signingKeyManager,
+    // ADR-0007: enable trusted-account mode only when the allowlist is non-empty.
+    ...(allowedDomains.size > 0 && {
+      trustedAccount: {
+        clientId: TRUSTED_ACCOUNT_CLIENT_ID,
+        allowedDomains,
+      },
+    }),
   })
 }
 

--- a/worker/routes/oauth.ts
+++ b/worker/routes/oauth.ts
@@ -125,8 +125,20 @@ app.get('/oauth/authorize', async (c) => {
 
   // Skip CSRF wrapping for service binding callers — the proxy handles its own security
   const isServiceBinding = !!c.req.header('X-Issuer')
+  // ADR-0007: also skip for the canonical trusted-account client. Trusted-
+  // account clients have `client.trusted === true`, which makes provider.ts
+  // (handleAuthorize, ~line 582) bypass the consent page and call
+  // issueAuthorizationCode directly — there's no consent POST round-trip
+  // where a wrapped state would be unwrapped, so the wrapped value would
+  // leak straight through to the consumer's better-auth callback and fail
+  // CSRF on that side. better-auth (and any standards-conformant OAuth
+  // client) compares the returned `state` against the one it sent and
+  // rejects on mismatch. Same failure mode as 08abc13 fixed for ChatGPT
+  // via the X-Issuer path; same fix shape.
+  const clientIdParam = new URL(c.req.url).searchParams.get('client_id') || ''
+  const isTrustedAccount = clientIdParam === TRUSTED_ACCOUNT_CLIENT_ID
 
-  if (isServiceBinding) {
+  if (isServiceBinding || isTrustedAccount) {
     const provider = getOAuthProvider(c)
     return provider.handleAuthorize(c.req.raw, identityId)
   }

--- a/worker/routes/oauth.ts
+++ b/worker/routes/oauth.ts
@@ -56,6 +56,13 @@ export function getOAuthProvider(c: any): OAuthProvider {
   const signingKeyManager = getSigningKeyManager(c.env)
   const base = 'https://id.org.ai'
   const allowedDomains = parseTrustedAccountDomains(c.env.TRUSTED_ACCOUNT_DOMAINS)
+  // ADR-0007 (BLOCKER 2): wire audit emission through the existing
+  // IdentityDO RPC. The DO routes to AuditService which writes immutable
+  // `audit:*` rows. Fire-and-forget on the provider side — the request
+  // flow never blocks on audit success. We layer the request's IP and UA
+  // onto the metadata-only event the provider constructs.
+  const reqIp = c.req.raw.headers.get('cf-connecting-ip') ?? undefined
+  const reqUa = c.req.raw.headers.get('user-agent') ?? undefined
   return new OAuthProvider({
     storage: {
       async get<T = unknown>(key: string): Promise<T | undefined> {
@@ -100,6 +107,22 @@ export function getOAuthProvider(c: any): OAuthProvider {
         allowedDomains,
       },
     }),
+    // ADR-0007 (BLOCKER 2): trusted-account audit emission. The provider
+    // only invokes this for trusted-account flows; DCR'd clients are
+    // intentionally untouched.
+    auditEmit: async (event) => {
+      // logFireAndForget on the DO swallows errors; we add one more layer
+      // here so even an RPC-level failure can't break /oauth/token.
+      try {
+        await stub.auditEvent({
+          ...event,
+          ip: event.ip ?? reqIp,
+          userAgent: event.userAgent ?? reqUa,
+        })
+      } catch {
+        // fire-and-forget
+      }
+    },
   })
 }
 

--- a/worker/types.ts
+++ b/worker/types.ts
@@ -31,6 +31,10 @@ export interface Env {
   APP_NAME?: string
   APP_TAGLINE?: string
   REDIRECT_URI?: string
+  // Trusted-account OAuth (ADR-0007). Comma-separated list of bare hostnames
+  // (e.g. "startup.games,foo.example") whose redirect_uri is accepted under
+  // the canonical shared client_id `cid_trusted_account_v1` without per-app DCR.
+  TRUSTED_ACCOUNT_DOMAINS?: string
 }
 
 export type Variables = {

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -31,6 +31,11 @@
     // Branding for @mdxui/auth SPA
     "APP_NAME": "id.org.ai",
     "APP_TAGLINE": "Humans. Agents. Identity.",
+    // Trusted-account OAuth (ADR-0007). Comma-separated list of bare hostnames
+    // (no scheme, no path) whose redirect_uri is accepted under the canonical
+    // shared client_id `cid_trusted_account_v1` without per-app DCR.
+    // Trust comes from the domain being in the same Cloudflare account.
+    "TRUSTED_ACCOUNT_DOMAINS": "startup.games",
   },
 
   "routes": [


### PR DESCRIPTION
Implements the issuer side of [ADR-0007](https://github.com/dot-do/startup.games/blob/main/docs/adr/0007-trusted-account-oauth-via-better-auth.md) — `/Users/nathanclevenger/projects/startup.games/docs/adr/0007-trusted-account-oauth-via-better-auth.md`.

## Summary

Adds a "trusted-account" OAuth mode: a single canonical shared `client_id` (`cid_trusted_account_v1`) is accepted at `/oauth/authorize` and `/oauth/token` for any `redirect_uri` whose host is in a configured allowlist. New in-Cloudflare-account consumer domains no longer need a per-app DCR call — they just need their host added to `TRUSTED_ACCOUNT_DOMAINS`.

## Validation relaxation rules (precise)

For incoming OAuth requests where `client_id === "cid_trusted_account_v1"`:

| Endpoint | Standard DCR client | Trusted-account client |
|---|---|---|
| `/oauth/authorize` client lookup | `storage.get("client:{cid_*}")`; 400 `invalid_client` if missing | Bypassed — virtual client synthesized from env config |
| `/oauth/authorize` `redirect_uri` check | Exact match against `client.redirectUris[]` | Parsed URL → exact-match host lookup in `TRUSTED_ACCOUNT_DOMAINS` (Set). Must be https (or localhost). No fragment. |
| `/oauth/authorize` PKCE | Required for public clients | **Unchanged — still required** |
| `/oauth/authorize` `response_type`, `scope`, `state` | Validated as usual | **Unchanged** |
| Consent screen | Shown unless `client.trusted === true` | Skipped (`trusted: true`) — account membership IS consent |
| `/oauth/token` `client_secret` | Required for confidential clients | Not required (public client, `tokenEndpointAuthMethod: 'none'`) |
| `/oauth/token` `redirect_uri` | Must match `codeData.redirectUri` | Must match `codeData.redirectUri` **and** host must still be in allowlist (defense in depth) |
| `/oauth/token` PKCE verifier | Verified as usual | **Unchanged — still verified** |

Non-trusted `client_id` values continue to hit the existing DCR storage path unchanged.

## Implementation choice (judgment call)

ADR-0007 offered two options for the canonical client:

- (a) provision a real `client:cid_trusted_account_v1` row in the DCR store via a one-time bootstrap
- (b) bypass the DCR lookup entirely when the incoming `client_id` matches the canonical id

**Picked (b).** Smaller diff (no bootstrap endpoint, no seeding step), and the virtual client's metadata (`grantTypes`, `scopes`, `trusted`, `tokenEndpointAuthMethod`) is fully derivable from env config. The trusted-account "client" is a function of the env, not a row in a database. This is documented inline in `src/sdk/oauth/provider.ts` and in `worker/routes/oauth.ts`.

## Files changed

- `worker/wrangler.jsonc` — add `TRUSTED_ACCOUNT_DOMAINS` var (initial value: `startup.games`)
- `worker/types.ts` — declare `TRUSTED_ACCOUNT_DOMAINS?: string` on `Env`
- `worker/routes/oauth.ts` — export `TRUSTED_ACCOUNT_CLIENT_ID` and `parseTrustedAccountDomains()`; pass `trustedAccount` to `OAuthProvider` when allowlist is non-empty
- `src/sdk/oauth/provider.ts` — add `TrustedAccountConfig`, `isTrustedAccountClient()`, `isTrustedAccountRedirect()`, `buildTrustedAccountClient()`; branch `handleAuthorize` and `handleAuthorizationCodeGrant` on trusted-account client
- `test/oauth-trusted-account.test.ts` — 15 new tests (see below)
- `README.md` — new "Trusted-Account OAuth (ADR-0007)" section under Key Design Decisions

## Test coverage

`test/oauth-trusted-account.test.ts` (15 tests, all passing):

- `parseTrustedAccountDomains` — empty input, comma-split + lowercase, defensive rejection of URL-like entries
- `/oauth/authorize` — happy path; sub-path/query OK; non-allowlisted host → 400; subdomain rejected when only apex allowlisted; http rejected; PKCE still required; non-trusted client → DCR path unchanged; no `trustedAccount` config → canonical id rejected
- `/oauth/token` — happy path with no `client_secret`; allowlist shrinking between authorize and token → 400 `invalid_grant`; `redirect_uri` body mismatch with code → 400 `invalid_grant`; wrong `code_verifier` still rejected

## What was deliberately NOT touched

Per ADR scope and task instructions: WorkOS integration, cookie helpers, `/callback`, `/api/callback`, DCR endpoints' behavior for non-trusted clients, JWT shape, claim names, JWKS. No package version bump. No database introduced.

## Test results

```
pnpm test
  Workers config: 50 test files / 1702 tests passed
  Node config:    27 test files /  520 tests passed
  Total:                          2222 tests passed, 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)